### PR TITLE
Instruct bash to fail harder

### DIFF
--- a/make-tom.sh
+++ b/make-tom.sh
@@ -1,5 +1,6 @@
 #! /bin/sh
 
+set -eo pipefail
 bold=$(tput bold)
 normal=$(tput sgr0)
 


### PR DESCRIPTION
Instructs bash to abort executing the script if any commands return a non-zero exit code, also unmasks failures in piped commands. See https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425 for explanations of these options.